### PR TITLE
RT-1000-457: RAM footprint optimizations in the nrf_provisioning module

### DIFF
--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -85,6 +85,10 @@ config NRF_PROVISIONING_PRINT_ATTESTATION_TOKEN
 	  nRF Cloud. Display the attestation token
 	  needed for claiming the device.
 
+config NRF_PROVISIONING_USE_MALLOC
+	bool "Use dynamic memory allocation for large structures"
+	default n
+
 rsource "Kconfig.nrf_provisioning_http"
 
 rsource "Kconfig.nrf_provisioning_coap"

--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
@@ -14,4 +14,8 @@ config NRF_PROVISIONING_CBOR_RECORDS
 	int "Maximum number of CBOR records that can be encoded or decoded at a time"
 	default 10
 
+config NRF_PROVISIONING_CBOR_PROP_COUNT
+	int "Maximum number of configuration properties that can be received"
+	default 100
+
 endif

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode_types.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode_types.h
@@ -28,6 +28,7 @@ extern "C" {
  *  See `zcbor --help` for more information about --default-max-qty
  */
 #define DEFAULT_MAX_QTY CONFIG_NRF_PROVISIONING_CBOR_RECORDS
+#define DEFAULT_MAX_PROPS CONFIG_NRF_PROVISIONING_CBOR_PROP_COUNT
 
 struct at_command {
 	struct zcbor_string at_command_set_command;
@@ -42,7 +43,7 @@ struct properties_tstrtstr {
 };
 
 struct config {
-	struct properties_tstrtstr properties_tstrtstr[100];
+	struct properties_tstrtstr properties_tstrtstr[DEFAULT_MAX_PROPS];
 	size_t properties_tstrtstr_count;
 };
 

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_codec.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_codec.h
@@ -11,6 +11,7 @@
 #include <modem/lte_lc.h>
 
 #include "nrf_provisioning_cbor_encode_types.h"
+#include "nrf_provisioning_cbor_decode_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +36,13 @@ struct cdc_context {
 	void *o_data; /* Raw responses */
 	size_t o_data_sz; /* Size of decoded commands */
 };
+
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+struct cdc_in_fmt_data {
+	/* Data */
+	struct commands cmds;
+};
+#endif
 
 /**
  *  @brief Initialize the codec used encoding the data to the cloud.

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
@@ -79,7 +79,7 @@ static bool decode_config(zcbor_state_t *state, struct config *result)
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (1)))) &&
 		   ((zcbor_map_start_decode(state) &&
-		     ((zcbor_multi_decode(0, 100, &(*result).properties_tstrtstr_count,
+		     ((zcbor_multi_decode(0, DEFAULT_MAX_PROPS, &(*result).properties_tstrtstr_count,
 					  (zcbor_decoder_t *)decode_repeated_properties_tstrtstr,
 					  state, (&(*result).properties_tstrtstr),
 					  sizeof(struct properties_tstrtstr))) ||

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -53,10 +53,14 @@ static struct cdc_out_fmt_data {
 	bool errors;
 } o_fmt_data;
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+static struct cdc_in_fmt_data *i_fmt_data;
+#else
 static struct cdc_in_fmt_data {
 	/* Data */
 	struct commands cmds;
 } i_fmt_data;
+#endif
 
 static struct cdc_context *cctx;
 
@@ -87,7 +91,18 @@ int nrf_provisioning_codec_setup(struct cdc_context *const cdc_ctx,
 	o_fmt_data.at_buff = at_buff;
 	o_fmt_data.at_buff_sz = at_buff_sz;
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	i_fmt_data = k_malloc(sizeof(struct cdc_in_fmt_data));
+
+	if (i_fmt_data == NULL) {
+		LOG_ERR("provisioning buf alloc error");
+		return -ENOMEM;
+	}
+
+	cctx->i_data = (void *)i_fmt_data;
+#else
 	cctx->i_data = (void *)&i_fmt_data;
+#endif
 	cctx->o_data = (void *)&o_fmt_data;
 
 	return 0;
@@ -99,6 +114,10 @@ int nrf_provisioning_codec_teardown(void)
 		k_free(o_fmt_data.msgs[i]);
 		o_fmt_data.msgs[i] = NULL;
 	}
+
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	k_free(i_fmt_data);
+#endif
 
 	return 0;
 }

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -390,12 +390,16 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 {
 	__ASSERT_NO_MSG(rest_ctx != NULL);
 
-	/* Only one provisioning ongoing at a time*/
-	static union {
-		char http[CONFIG_NRF_PROVISIONING_TX_BUF_SZ];
-		char at[CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN];
-	} tx_buf;
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	char *rx_buf, *tx_buf = NULL;
+	size_t tx_buf_sz = MAX(CONFIG_NRF_PROVISIONING_TX_BUF_SZ,
+			CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN);
+#else
+	static char tx_buf[MAX(CONFIG_NRF_PROVISIONING_TX_BUF_SZ,
+			CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN)];
+	size_t tx_buf_sz = sizeof(tx_buf);
 	static char rx_buf[CONFIG_NRF_PROVISIONING_RX_BUF_SZ];
+#endif
 
 	char *auth_hdr = NULL;
 	struct rest_client_req_context req;
@@ -404,8 +408,17 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 	struct cdc_context cdc_ctx;
 	bool finished = false;
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	rx_buf = k_malloc(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
+	tx_buf = k_malloc(tx_buf_sz);
+	if (!rx_buf || !tx_buf) {
+		ret = -ENOMEM;
+		goto done;
+	}
+#endif
+
 	rest_ctx->rx_buf = rx_buf;
-	rest_ctx->rx_buf_len = sizeof(rx_buf);
+	rest_ctx->rx_buf_len = CONFIG_NRF_PROVISIONING_RX_BUF_SZ;
 	rest_ctx->keep_alive = false;
 
 	/* While there are commands to be processed */
@@ -474,13 +487,18 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 			 * responses. This does break the layering of code but needs to be done
 			 * to achieve the memory savings.
 			 */
-			nrf_provisioning_codec_setup(&cdc_ctx, tx_buf.at, sizeof(tx_buf));
+
+			ret = nrf_provisioning_codec_setup(&cdc_ctx, tx_buf, tx_buf_sz);
+
+			if (ret < 0) {
+				break;
+			}
 
 			/* Codec input and output buffers */
 			cdc_ctx.ipkt = resp.response;
 			cdc_ctx.ipkt_sz = resp.response_len;
-			cdc_ctx.opkt = tx_buf.http;
-			cdc_ctx.opkt_sz = sizeof(tx_buf);
+			cdc_ctx.opkt = tx_buf;
+			cdc_ctx.opkt_sz = tx_buf_sz;
 
 			LOG_INF("Processing commands");
 			ret = nrf_provisioning_codec_process_commands();
@@ -518,6 +536,12 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 		}
 		break;
 	}
+
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+done:
+	k_free(rx_buf);
+	k_free(tx_buf);
+#endif
 
 	nrf_provisioning_codec_teardown();
 


### PR DESCRIPTION
*  net: lib: nrf_provisioning: allow to configure amount of CBOR properties
*  net: lib: nrf_provisioning: add support for dynamic buffer allocation
