### PR TITLE
RT-1000-498: net: lib: nrf_cloud: Convert version string of the FOTA SMP device

### DIFF
--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -1183,6 +1183,17 @@ int nrf_cloud_fota_smp_version_read(void);
  */
 int nrf_cloud_fota_smp_version_get(char **smp_ver_out);
 
+#if defined(CONFIG_NRF_CLOUD_FOTA_SMP_CONVERT_VERSION)
+/**
+ * @brief Convert the version string of the SMP device to a custom format.
+ *
+ * @retval 0        Success.
+ * @retval -ENOBUFS Error; internal buffer is too small to hold version string.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_fota_smp_version_convert(char **smp_ver_out);
+#endif
+
 /**
  * @brief Check if credentials exist in the configured location.
  *

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -135,6 +135,14 @@ config NRF_CLOUD_FOTA_SMP
 	help
 	  Enables FOTA updates to an auxiliary MCU using SMP.
 
+config NRF_CLOUD_FOTA_SMP_CONVERT_VERSION
+	bool "Convert the version string of the SMP device to a custom format"
+	default n
+	depends on NRF_CLOUD_FOTA_SMP
+	help
+	  Calls the custom nrf_cloud_fota_smp_version_convert() function
+	  to re-format the version string of the SMP device.
+
 config NRF_CLOUD_FOTA_TRANSPORT_ENABLED
 	bool
 	default y if (NRF_CLOUD_REST || NRF_CLOUD_COAP || NRF_CLOUD_FOTA)

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -575,6 +575,9 @@ int nrf_cloud_fota_smp_version_get(char **smp_ver_out)
 	}
 
 	*smp_ver_out = smp_ver;
+#if defined(CONFIG_NRF_CLOUD_FOTA_SMP_CONVERT_VERSION)
+	nrf_cloud_fota_smp_version_convert(smp_ver_out);
+#endif
 
 	return 0;
 #endif


### PR DESCRIPTION
The version format of some FOTA SMP devices does not match the MCUboot version format, so a conversion is required