### PR TITLE
manifest: Integrate HAL TDK module into nRF Connect SDK v2.8.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,6 +98,7 @@ manifest:
           - fatfs
           - hal_nordic
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
+          - hal_tdk
           - hal_wurthelektronik
           - hostap
           - liblc3


### PR DESCRIPTION
RM7337: Integrate HAL TDK module into nRF Connect SDK v2.8.0