### PR TITLE
app_event_manager: move event processing to a separate work queue

### DIFF
--- a/subsys/app_event_manager/Kconfig
+++ b/subsys/app_event_manager/Kconfig
@@ -111,4 +111,10 @@ config APP_EVENT_MANAGER_POSTPROCESS_HOOKS
 	  This option is here for optimisation purposes.
 	  When postprocess hook is not in use the related code may be removed.
 
+config APP_EVENT_MANAGER_STACK_SIZE
+  int "Event manager stack size"
+  default 2048
+  help
+    Set stack size for the work queue serving events
+
 endif # APP_EVENT_MANAGER

--- a/subsys/app_event_manager/app_event_manager.c
+++ b/subsys/app_event_manager/app_event_manager.c
@@ -19,7 +19,11 @@ static void event_processor_fn(struct k_work *work);
 
 struct app_event_manager_event_display_bm _app_event_manager_event_display_bm;
 
+#define THREAD_PRIORITY		(K_LOWEST_APPLICATION_THREAD_PRIO - 1)
 static K_WORK_DEFINE(event_processor, event_processor_fn);
+K_THREAD_STACK_DEFINE(event_process_stack_area, CONFIG_APP_EVENT_MANAGER_STACK_SIZE);
+static struct k_work_q event_process_work_q;
+
 static sys_slist_t eventq = SYS_SLIST_STATIC_INIT(&eventq);
 static struct k_spinlock lock;
 
@@ -227,15 +231,20 @@ void _event_submit(struct app_event_header *aeh)
 	sys_slist_append(&eventq, &aeh->node);
 	k_spin_unlock(&lock, key);
 
-	k_work_submit(&event_processor);
+	k_work_submit_to_queue(&event_process_work_q, &event_processor);
 }
 
 int app_event_manager_init(void)
 {
 	int ret = 0;
+	struct k_work_queue_config cfg = { .name = "event_process", };
 
 	__ASSERT_NO_MSG(_event_type_list_end - _event_type_list_start <=
 			CONFIG_APP_EVENT_MANAGER_MAX_EVENT_CNT);
+
+	k_work_queue_init(&event_process_work_q);
+	k_work_queue_start(&event_process_work_q, event_process_stack_area,
+      K_THREAD_STACK_SIZEOF(event_process_stack_area), THREAD_PRIORITY, &cfg);
 
 	log_event_init();
 


### PR DESCRIPTION
RT-1000-713:
 - Processing of some events may take significant time, and delay the system workq. Such delays can affect other subsystems, so move event processing to a separate workq.