### PR TITLE
net: lib: nrf_provisioning: use libc heap for memory allocation

### DIFF
--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_coap
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_coap
@@ -6,6 +6,7 @@
 menuconfig NRF_PROVISIONING_COAP
 	bool "nRF Provisioning COAP"
 	select EXPERIMENTAL
+	imply COMMON_LIBC_MALLOC
 	imply COAP
 	imply COAP_CLIENT
 

--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_http
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_http
@@ -7,6 +7,7 @@
 menuconfig NRF_PROVISIONING_HTTP
 	bool "nRF Provisioning HTTP"
 	select EXPERIMENTAL
+	imply COMMON_LIBC_MALLOC
 	imply REST_CLIENT
 
 if NRF_PROVISIONING_HTTP

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -18,6 +18,10 @@
 #include "nrf_provisioning_coap.h"
 #include "nrf_provisioning_jwt.h"
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+#include <stdlib.h>
+#endif
+
 LOG_MODULE_REGISTER(nrf_provisioning_coap, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 
 #if !defined(CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG)
@@ -356,7 +360,11 @@ static int generate_auth_token(char **auth_token)
 		return -EINVAL;
 	}
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	*auth_token = malloc(tok_len);
+#else
 	*auth_token = k_malloc(tok_len);
+#endif
 	if (!*auth_token) {
 		return -ENOMEM;
 	}
@@ -374,7 +382,11 @@ static int generate_auth_token(char **auth_token)
 	return 0;
 
 fail:
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	free(*auth_token);
+#else
 	k_free(*auth_token);
+#endif
 	*auth_token = NULL;
 
 	return ret;
@@ -672,7 +684,11 @@ int nrf_provisioning_coap_req(struct nrf_provisioning_coap_context *const coap_c
 	nrf_provisioning_codec_teardown();
 
 	if (auth_token) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(auth_token);
+#else
 		k_free(auth_token);
+#endif
 	}
 
 	socket_close(&coap_ctx->connect_socket);

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -6,6 +6,9 @@
 
 #include <string.h>
 #include <stdio.h>
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+#include <stdlib.h>
+#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -92,7 +95,7 @@ int nrf_provisioning_codec_setup(struct cdc_context *const cdc_ctx,
 	o_fmt_data.at_buff_sz = at_buff_sz;
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
-	i_fmt_data = k_malloc(sizeof(struct cdc_in_fmt_data));
+	i_fmt_data = malloc(sizeof(struct cdc_in_fmt_data));
 
 	if (i_fmt_data == NULL) {
 		LOG_ERR("provisioning buf alloc error");
@@ -111,12 +114,16 @@ int nrf_provisioning_codec_setup(struct cdc_context *const cdc_ctx,
 int nrf_provisioning_codec_teardown(void)
 {
 	for (int i = 0; i < CONFIG_NRF_PROVISIONING_CBOR_RECORDS; i++) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(o_fmt_data.msgs[i]);
+#else
 		k_free(o_fmt_data.msgs[i]);
+#endif
 		o_fmt_data.msgs[i] = NULL;
 	}
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
-	k_free(i_fmt_data);
+	free(i_fmt_data);
 #endif
 
 	return 0;
@@ -298,7 +305,11 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 	}
 
 	while (true) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		resp = malloc(resp_sz);
+#else
 		resp = k_malloc(resp_sz);
+#endif
 		if (!resp) {
 			LOG_ERR("Unable to write response msg field");
 			return -ENOMEM;
@@ -313,7 +324,11 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 			int type = 0;
 
 			LOG_DBG("Buffer too small for AT response, retrying");
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+			free(resp);
+#else
 			k_free(resp);
+#endif
 			resp = NULL;
 			if (sscanf(out->at_buff, "AT%%KEYGEN=%d,%d,%*s", &tag, &type) == 2) {
 				LOG_DBG("Clear sec_tag %d, type %d", tag, type);
@@ -386,19 +401,31 @@ static int write_config(struct command *cmd_req, struct cdc_out_fmt_data *out)
 		max_value_sz = MAX(max_value_sz, pair->properties_tstrtstr.len + 1);
 	}
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	key = malloc(max_key_sz);
+#else
 	key = k_malloc(max_key_sz);
+#endif
 	if (!key) {
 		ret = -ENOMEM;
 		goto exit;
 	}
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	value = malloc(max_value_sz);
+#else
 	value = k_malloc(max_value_sz);
+#endif
 	if (!value) {
 		ret = -ENOMEM;
 		goto exit;
 	}
 
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	resp = malloc(resp_sz);
+#else
 	resp = k_malloc(resp_sz);
+#endif
 	if (!resp) {
 		ret = -ENOMEM;
 		goto exit;
@@ -434,15 +461,27 @@ static int write_config(struct command *cmd_req, struct cdc_out_fmt_data *out)
 	}
 
 	/* No error to report */
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	free(resp);
+#else
 	k_free(resp);
+#endif
 	resp = NULL;
 
 exit:
 	if (key) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(key);
+#else
 		k_free(key);
+#endif
 	}
 	if (value) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(value);
+#else
 		k_free(value);
+#endif
 	}
 
 	/* Keeps track of response messages to be freed once the whole responses request is send */

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -160,7 +160,11 @@ static int generate_auth_header(char **auth_hdr_out)
 	prefix_len = max_auth_prefix_len();
 
 	hdr_size = prefix_len + tok_len + postfix_len + 1;
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	*auth_hdr_out = malloc(hdr_size);
+#else
 	*auth_hdr_out = k_malloc(hdr_size);
+#endif
 	if (!*auth_hdr_out) {
 		return -ENOMEM;
 	}
@@ -188,7 +192,11 @@ static int generate_auth_header(char **auth_hdr_out)
 	return 0;
 
 fail:
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	free(*auth_hdr_out);
+#else
 	k_free(*auth_hdr_out);
+#endif
 	*auth_hdr_out = NULL;
 
 	return ret;
@@ -228,7 +236,11 @@ static int gen_result_url(struct rest_client_req_context *const req)
 	int ret;
 
 	buff_sz = sizeof(API_POST_RSLT);
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	url = malloc(buff_sz);
+#else
 	url = k_malloc(buff_sz);
+#endif
 	if (!url) {
 		ret = -ENOMEM;
 		return ret;
@@ -280,7 +292,11 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 	buff_sz = sizeof(API_CMDS_TEMPLATE) +
 		strlen(after) + strlen(rx_buf_sz) + strlen(tx_buf_sz) +
 		strlen(mvernmb) + strlen(cver);
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+	url = malloc(buff_sz);
+#else
 	url = k_malloc(buff_sz);
+#endif
 	if (!url) {
 		ret = -ENOMEM;
 		return ret;
@@ -376,11 +392,19 @@ static int nrf_provisioning_responses_req(struct nrf_provisioning_http_context *
 
 clean_up:
 	if (req->url) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free((char *)req->url);
+#else
 		k_free((char *)req->url);
+#endif
 		req->url = NULL;
 	}
 	if (auth_hdr) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(auth_hdr);
+#else
 		k_free(auth_hdr);
+#endif
 	}
 
 	return ret;
@@ -409,8 +433,8 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 	bool finished = false;
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
-	rx_buf = k_malloc(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
-	tx_buf = k_malloc(tx_buf_sz);
+	rx_buf = malloc(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
+	tx_buf = malloc(tx_buf_sz);
 	if (!rx_buf || !tx_buf) {
 		ret = -ENOMEM;
 		goto done;
@@ -449,9 +473,17 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 
 		LOG_INF("Requesting commands");
 		ret = rest_client_request(&req, &resp);
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(auth_hdr);
+#else
 		k_free(auth_hdr);
+#endif
 		auth_hdr = NULL;
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free((char *)req.url);
+#else
 		k_free((char *)req.url);
+#endif
 		req.url = NULL;
 
 		if (ret < 0) {
@@ -539,17 +571,25 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
 done:
-	k_free(rx_buf);
-	k_free(tx_buf);
+	free(rx_buf);
+	free(tx_buf);
 #endif
 
 	nrf_provisioning_codec_teardown();
 
 	if (req.url) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free((char *)req.url);
+#else
 		k_free((char *)req.url);
+#endif
 	}
 	if (auth_hdr) {
+#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+		free(auth_hdr);
+#else
 		k_free(auth_hdr);
+#endif
 	}
 
 	return ret;


### PR DESCRIPTION
Fixes RT-1000-899.