### PR TITLE
lib: nrf_provisioning: Add heap allocation option for HTTP buffers

### DIFF
--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -89,6 +89,19 @@ config NRF_PROVISIONING_USE_MALLOC
 	bool "Use dynamic memory allocation for large structures"
 	default n
 
+config NRF_PROVISIONING_USE_KMALLOC
+	bool "Allocate provisioning RX/TX buffers from the kernel heap"
+	depends on !NRF_PROVISIONING_USE_MALLOC
+	default n
+	help
+	  Allocate the provisioning HTTP RX/TX buffers with k_malloc() for the
+	  duration of a provisioning exchange instead of reserving them as
+	  permanent static arrays (the default when USE_MALLOC is off). Trades a
+	  large static reservation (RX_BUF_SZ + TX_BUF_SZ) for transient kernel-
+	  heap usage, freeing static RAM on memory-constrained images. Requires
+	  CONFIG_HEAP_MEM_POOL_SIZE large enough to hold RX_BUF_SZ + TX_BUF_SZ on
+	  top of other concurrent kernel-heap users.
+
 rsource "Kconfig.nrf_provisioning_http"
 
 rsource "Kconfig.nrf_provisioning_coap"

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_codec.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_codec.h
@@ -37,7 +37,7 @@ struct cdc_context {
 	size_t o_data_sz; /* Size of decoded commands */
 };
 
-#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+#if defined(CONFIG_NRF_PROVISIONING_USE_MALLOC) || defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
 struct cdc_in_fmt_data {
 	/* Data */
 	struct commands cmds;

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -56,7 +56,7 @@ static struct cdc_out_fmt_data {
 	bool errors;
 } o_fmt_data;
 
-#ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
+#if defined(CONFIG_NRF_PROVISIONING_USE_MALLOC) || defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
 static struct cdc_in_fmt_data *i_fmt_data;
 #else
 static struct cdc_in_fmt_data {
@@ -103,6 +103,15 @@ int nrf_provisioning_codec_setup(struct cdc_context *const cdc_ctx,
 	}
 
 	cctx->i_data = (void *)i_fmt_data;
+#elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
+	i_fmt_data = k_malloc(sizeof(struct cdc_in_fmt_data));
+
+	if (i_fmt_data == NULL) {
+		LOG_ERR("provisioning buf alloc error");
+		return -ENOMEM;
+	}
+
+	cctx->i_data = (void *)i_fmt_data;
 #else
 	cctx->i_data = (void *)&i_fmt_data;
 #endif
@@ -124,6 +133,8 @@ int nrf_provisioning_codec_teardown(void)
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
 	free(i_fmt_data);
+#elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
+	k_free(i_fmt_data);
 #endif
 
 	return 0;

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -418,6 +418,10 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 	char *rx_buf, *tx_buf = NULL;
 	size_t tx_buf_sz = MAX(CONFIG_NRF_PROVISIONING_TX_BUF_SZ,
 			CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN);
+#elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
+	char *rx_buf = NULL, *tx_buf = NULL;
+	size_t tx_buf_sz = MAX(CONFIG_NRF_PROVISIONING_TX_BUF_SZ,
+			CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN);
 #else
 	static char tx_buf[MAX(CONFIG_NRF_PROVISIONING_TX_BUF_SZ,
 			CONFIG_NRF_PROVISIONING_CODEC_AT_CMD_LEN)];
@@ -435,6 +439,13 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
 	rx_buf = malloc(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
 	tx_buf = malloc(tx_buf_sz);
+	if (!rx_buf || !tx_buf) {
+		ret = -ENOMEM;
+		goto done;
+	}
+#elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
+	rx_buf = k_malloc(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
+	tx_buf = k_malloc(tx_buf_sz);
 	if (!rx_buf || !tx_buf) {
 		ret = -ENOMEM;
 		goto done;
@@ -573,6 +584,10 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 done:
 	free(rx_buf);
 	free(tx_buf);
+#elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
+done:
+	k_free(rx_buf);
+	k_free(tx_buf);
 #endif
 
 	nrf_provisioning_codec_teardown();


### PR DESCRIPTION
Add CONFIG_NRF_PROVISIONING_USE_KMALLOC to allocate provisioning HTTP RX/TX buffers and codec data from the kernel heap instead of reserving them as permanent static memory.

This reduces static RAM usage by allocating the buffers only during a provisioning exchange and freeing them afterwards. The tradeoff is that the heap must be large enough to hold RX_BUF_SZ + TX_BUF_SZ and other
concurrent allocations.

Reuse the existing pointer-based codec layout used by USE_MALLOC; only the allocator differs (k_malloc/k_free vs malloc/free).