### PR TITLE
lib: nrf_provisioning: Fix double-free and possible heap corruption

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -133,8 +133,10 @@ int nrf_provisioning_codec_teardown(void)
 
 #ifdef CONFIG_NRF_PROVISIONING_USE_MALLOC
 	free(i_fmt_data);
+	i_fmt_data = NULL;
 #elif defined(CONFIG_NRF_PROVISIONING_USE_KMALLOC)
 	k_free(i_fmt_data);
+	i_fmt_data = NULL;
 #endif
 
 	return 0;

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -430,7 +430,7 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 #endif
 
 	char *auth_hdr = NULL;
-	struct rest_client_req_context req;
+	struct rest_client_req_context req = {0};
 	struct rest_client_resp_context resp;
 	int ret;
 	struct cdc_context cdc_ctx;


### PR DESCRIPTION
Fix double-free issue and potential stack corruption
